### PR TITLE
Add initial JFM forecasting CLI and engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+.runs/
+runs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.15
+    hooks:
+      - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.0 - 2025-09-13
+- Initial MVP.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joern Stoehler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# forecast
+# JFM
+
+Joern's Forecasting Model (JFM) is a minimal forecasting engine driven by a
+causal graph defined in YAML. The project exposes a small CLI for validating
+and simulating the sample graph.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+```
+
+System Graphviz is required for the `render` command.
+
+## CLI
+
+All commands operate on the sample graph in `model/current.yaml`.
+
+```bash
+python -m jfm.cli validate model/current.yaml
+python -m jfm.cli simulate model/current.yaml
+python -m jfm.cli render model/current.yaml
+```
+
+Simulation outputs are written under `runs/<timestamp>/`.
+
+## Contributing
+
+Run `pre-commit run --files <files>` and `pytest` before committing.

--- a/forecasts/ledger.csv
+++ b/forecasts/ledger.csv
@@ -1,0 +1,1 @@
+qid,question,open_date,close_date,p,resolution_rule,primary_sources,top_drivers,rationale_stub,last_updated

--- a/jfm/__init__.py
+++ b/jfm/__init__.py
@@ -1,0 +1,4 @@
+"""Joern's Forecasting Model package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/jfm/cli.py
+++ b/jfm/cli.py
@@ -1,0 +1,48 @@
+"""Typer-based CLI for JFM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import typer
+
+from .io.loader import load_graph, ValidationError
+from .model import engine, sensitivity, render as renderer
+
+app = typer.Typer()
+
+
+@app.command()
+def validate(path: Path) -> None:
+    """Validate a model YAML file against the schema."""
+    try:
+        load_graph(path)
+    except ValidationError as e:
+        typer.echo(f"Invalid: {e}")
+        raise typer.Exit(code=1)
+    typer.echo("valid")
+
+
+@app.command()
+def simulate(path: Path, runs: int = 1000, seed: int = 0) -> None:
+    """Run a Monte Carlo simulation."""
+    summary = engine.simulate(path, runs=runs, seed=seed)
+    typer.echo(json.dumps(summary, indent=2))
+
+
+@app.command()
+def sensitivity_cmd(path: Path, runs: int = 100, seed: int = 0) -> None:
+    """Placeholder sensitivity analysis."""
+    result = sensitivity.one_at_a_time(path, runs=runs, seed=seed)
+    typer.echo(json.dumps(result, indent=2))
+
+
+@app.command()
+def render(path: Path, out: Path = Path("graph")) -> None:
+    """Render the model graph to an SVG file."""
+    renderer.render(path, out)
+    typer.echo(f"wrote {out.with_suffix('.svg')}")
+
+
+if __name__ == "__main__":
+    app()

--- a/jfm/io/__init__.py
+++ b/jfm/io/__init__.py
@@ -1,0 +1,5 @@
+"""IO package."""
+
+from .loader import load_graph, ValidationError
+
+__all__ = ["load_graph", "ValidationError"]

--- a/jfm/io/loader.py
+++ b/jfm/io/loader.py
@@ -1,0 +1,28 @@
+"""Graph loader and validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from .schema import load_graph_schema
+
+
+class ValidationError(Exception):
+    """Raised when the input graph fails schema validation."""
+
+
+def load_graph(path: str | Path) -> dict[str, Any]:
+    """Load a YAML graph and validate against the JSON schema."""
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    schema = load_graph_schema()
+    try:
+        jsonschema.validate(data, schema)
+    except jsonschema.ValidationError as e:
+        raise ValidationError(str(e)) from e
+    return data

--- a/jfm/io/schema.py
+++ b/jfm/io/schema.py
@@ -1,0 +1,16 @@
+"""Schema helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2] / "model" / "schemas" / "graph.schema.json"
+)
+
+
+def load_graph_schema() -> dict:
+    """Load and return the graph JSON schema."""
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)

--- a/jfm/model/__init__.py
+++ b/jfm/model/__init__.py
@@ -1,0 +1,8 @@
+"""Model package."""
+
+from . import edges
+from .engine import simulate
+from .sensitivity import one_at_a_time
+from .render import render
+
+__all__ = ["edges", "simulate", "one_at_a_time", "render"]

--- a/jfm/model/edges.py
+++ b/jfm/model/edges.py
@@ -1,0 +1,36 @@
+"""Edge functions for the causal graph."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+
+def logistic(x: float, w: float, b: float) -> float:
+    return 1 / (1 + math.exp(-(w * x + b)))
+
+
+def inhibitory_logistic(x: float, w: float, b: float) -> float:
+    return logistic(x, w, b)
+
+
+def multiplicative(x: float, alpha: float) -> float:
+    return x * alpha
+
+
+def gate_min(x: float, risk_multiplier: float) -> float:
+    return min(x, x * risk_multiplier)
+
+
+def gate_max(
+    x: float, policy: float, max_multiplier: float, min_multiplier: float
+) -> float:
+    mult = min_multiplier + (max_multiplier - min_multiplier) * policy
+    return x * mult
+
+
+def noisy_or(sources: Iterable[float], p_leak: float) -> float:
+    prod = 1.0
+    for s in sources:
+        prod *= 1 - s
+    return 1 - (1 - p_leak) * prod

--- a/jfm/model/engine.py
+++ b/jfm/model/engine.py
@@ -1,0 +1,61 @@
+"""Simple Monte Carlo engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import json
+from datetime import datetime
+
+import numpy as np
+
+from ..io.loader import load_graph
+from ..util import stats
+from .edges import noisy_or
+
+
+def simulate(path: str | Path, runs: int = 1000, seed: int = 0) -> Dict[str, float]:
+    """Run a one-quarter Monte Carlo simulation."""
+    graph = load_graph(path)
+    rng = np.random.default_rng(seed)
+
+    node_ids = [n["id"] for n in graph["nodes"]]
+    summaries = {nid: [] for nid in node_ids}
+    n12_vals = []
+
+    # find parameters for special edges
+    noisy_edge = next(e for e in graph["edges"] if e["function"] == "noisy_or")
+    gate_edge = next(e for e in graph["edges"] if e["function"] == "gate_min")
+
+    for _ in range(runs):
+        values: Dict[str, float] = {}
+        for node in graph["nodes"]:
+            prior = node.get("prior")
+            if prior:
+                values[node["id"]] = stats.sample(prior, rng)
+        n5 = values.get("N5", 0.0)
+        n9 = values.get("N9", 0.0)
+        p = noisy_or([n5, n9], noisy_edge["params"]["p_leak"])
+        n11 = values.get(gate_edge["source"], 1.0)
+        risk_mult = gate_edge["params"].get("risk_multiplier", 1.0)
+        p = min(p, p * risk_mult * n11)
+        n12_vals.append(p)
+        for nid in values:
+            summaries[nid].append(values[nid])
+
+    summary = {
+        "seed": seed,
+        "runs": runs,
+        "P(N12)": float(np.mean(n12_vals)),
+        "nodes": {
+            nid: {"mean": float(np.mean(vals))} for nid, vals in summaries.items()
+        },
+    }
+
+    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_dir = Path("runs") / ts
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "summary.json", "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    return summary

--- a/jfm/model/render.py
+++ b/jfm/model/render.py
@@ -1,0 +1,21 @@
+"""Graph rendering utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphviz import Digraph
+
+from ..io.loader import load_graph
+
+
+def render(path: str | Path, out_path: str | Path) -> None:
+    graph = load_graph(path)
+    dot = Digraph()
+    for node in graph["nodes"]:
+        dot.node(node["id"], node.get("name", node["id"]))
+    for edge in graph["edges"]:
+        sources = edge.get("sources") or [edge.get("source")]
+        for src in sources:
+            dot.edge(src, edge["target"], label=edge["function"])
+    dot.render(out_path, format="svg", cleanup=True)

--- a/jfm/model/sensitivity.py
+++ b/jfm/model/sensitivity.py
@@ -1,0 +1,14 @@
+"""Sensitivity analysis stubs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from .engine import simulate
+
+
+def one_at_a_time(path: str | Path, runs: int = 100, seed: int = 0) -> Dict[str, float]:
+    """Very small placeholder one-at-a-time sensitivity analysis."""
+    base = simulate(path, runs=runs, seed=seed)
+    return {"baseline": base["P(N12)"]}

--- a/jfm/model/types.py
+++ b/jfm/model/types.py
@@ -1,0 +1,30 @@
+"""Pydantic models for nodes and edges."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Prior(BaseModel):
+    dist: str
+    a: Optional[float] = None
+    b: Optional[float] = None
+    mu: Optional[float] = None
+    sigma: Optional[float] = None
+
+
+class Node(BaseModel):
+    id: str
+    name: Optional[str] = None
+    type: Optional[str] = None
+    prior: Optional[Prior] = None
+
+
+class Edge(BaseModel):
+    source: Optional[str] = None
+    sources: Optional[List[str]] = None
+    target: str
+    function: str
+    params: Dict[str, float] = {}

--- a/jfm/util/__init__.py
+++ b/jfm/util/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers."""
+
+from .stats import sample
+from .log import get_logger
+
+__all__ = ["sample", "get_logger"]

--- a/jfm/util/log.py
+++ b/jfm/util/log.py
@@ -1,0 +1,17 @@
+"""Simple structured logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/jfm/util/stats.py
+++ b/jfm/util/stats.py
@@ -1,0 +1,21 @@
+"""Distribution helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+
+def sample(prior: Dict[str, float], rng: np.random.Generator) -> float:
+    """Sample a value from a prior definition."""
+    dist = prior.get("dist")
+    if dist == "Beta":
+        a = prior["a"]
+        b = prior["b"]
+        return float(rng.beta(a, b))
+    if dist == "LogNormal":
+        mu = prior["mu"]
+        sigma = prior["sigma"]
+        return float(rng.lognormal(mean=mu, sigma=sigma))
+    raise ValueError(f"Unsupported distribution: {dist}")

--- a/model/current.yaml
+++ b/model/current.yaml
@@ -1,0 +1,42 @@
+meta:
+  id: MVG-AXR-12
+  version: 0.1
+  timestep: quarter
+nodes:
+  - {id: N1, name: Frontier_Capability_Level, type: state, range: [0,1], prior: {dist: Beta, a: 2, b: 3}}
+  - {id: N2, name: Training_Compute_Available, type: resource, unit: H100eq, prior: {dist: LogNormal, mu: 10, sigma: 0.6}}
+  - {id: N3, name: Algorithmic_Efficiency, type: state, prior: {dist: LogNormal, mu: 0, sigma: 0.4}}
+  - {id: N4, name: Deployment_Intensity_HighStakes, type: state, range: [0,1], prior: {dist: Beta, a: 2, b: 2}}
+  - {id: N5, name: Deceptive_Alignment_Prevalence, type: state, range: [0,1], prior: {dist: Beta, a: 1.5, b: 3}}
+  - {id: N6, name: Eval_Efficacy, type: state, range: [0,1], prior: {dist: Beta, a: 2.5, b: 2.5}}
+  - {id: N7, name: Governance_Stringency, type: policy, range: [0,1], prior: {dist: Beta, a: 1.8, b: 2.2}}
+  - {id: N8, name: Org_Risk_Incentives, type: state, range: [0,1], prior: {dist: Beta, a: 2.5, b: 2}}
+  - {id: N9, name: Incident_Rate_Severe, type: rate, unit: per_1000, prior: {dist: LogNormal, mu: -2, sigma: 0.8}}
+  - {id: N10, name: Public_Opinion_Risk_Salience, type: state, range: [0,1], prior: {dist: Beta, a: 1.6, b: 2.4}}
+  - {id: N11, name: Emergency_Response_Capacity, type: state, range: [0,1], prior: {dist: Beta, a: 2.2, b: 1.8}}
+  - {id: N12, name: Loss_of_Control_Event, type: event, window: quarter}
+edges:
+  - {source: N2, target: N1, function: logistic, params: {w: 0.8, b: -1.0}, justification: J1}
+  - {source: N3, target: N1, function: logistic, params: {w: 0.7, b: -0.6}, justification: J2}
+  - {source: N7, target: N2, function: gate_max, params: {max_multiplier: 1.0, min_multiplier: 0.4}, justification: J3}
+  - {source: N8, target: N4, function: logistic, params: {w: 1.0, b: -0.5}, justification: J4}
+  - {source: N1, target: N4, function: logistic, params: {w: 0.6, b: -0.3}, justification: J4}
+  - {source: N1, target: N9, function: multiplicative, params: {alpha: 0.02}, justification: J5}
+  - {source: N4, target: N9, function: multiplicative, params: {alpha: 0.03}, justification: J5}
+  - {source: N6, target: N5, function: inhibitory_logistic, params: {w: -1.2, b: 0.0}, justification: J6}
+  - {source: N1, target: N5, function: logistic, params: {w: 0.9, b: -0.7}, justification: J7}
+  - {sources: [N5, N9], target: N12, function: noisy_or, params: {p_leak: 0.005}, justification: J8}
+  - {source: N10, target: N7, function: logistic, params: {w: 0.9, b: -0.7}, justification: J9}
+  - {source: N9, target: N10, function: logistic, params: {w: 1.1, b: -1.0}, justification: J9}
+  - {source: N11, target: N12, function: gate_min, params: {risk_multiplier: 0.3}, justification: J10}
+justifications:
+  J1: "Compute enables capability; governance can cap effective compute."
+  J2: "Algorithmic efficiency gains substitute for compute growth."
+  J3: "Policy can constrain access to top-tier hardware/runs."
+  J4: "Risk incentives and capability drive high-stakes deployment."
+  J5: "Higher capability/deployment → more severe incidents per unit time."
+  J6: "Better evals reduce deceptive alignment prevalence detected before deployment."
+  J7: "At higher capability, deception becomes easier/more instrumentally useful."
+  J8: "Either prevalent deception or severe incidents can precipitate loss-of-control."
+  J9: "Incidents move public salience, which drives governance stringency (lagged)."
+  J10: "Emergency levers (audit, shutdown, rollback) reduce realized catastrophe."

--- a/model/schemas/evidence.schema.yaml
+++ b/model/schemas/evidence.schema.yaml
@@ -1,0 +1,1 @@
+# Placeholder for evidence schema

--- a/model/schemas/graph.schema.json
+++ b/model/schemas/graph.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["meta", "nodes", "edges"],
+  "properties": {
+    "meta": {"type": "object"},
+    "nodes": {"type": "array"},
+    "edges": {"type": "array"}
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "jfm"
+version = "0.1.0"
+description = "Joern's Forecasting Model"
+authors = [{name = "Joern Stoehler"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+
+[project.dependencies]
+pydantic = ">=2,<3"
+jsonschema = ">=4,<5"
+pyyaml = ">=6,<7"
+numpy = ">=1.26,<3"
+typer = ">=0.12,<0.13"
+graphviz = ">=0.20,<0.21"
+
+[project.optional-dependencies]
+test = ["pytest>=8,<9"]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/refs/README.md
+++ b/refs/README.md
@@ -1,0 +1,1 @@
+Reference materials.

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from jfm.model import edges  # noqa: E402
+
+
+def test_logistic_monotonic():
+    x1, x2 = 0.1, 0.9
+    y1 = edges.logistic(x1, w=1.0, b=0.0)
+    y2 = edges.logistic(x2, w=1.0, b=0.0)
+    assert y1 < y2
+
+
+def test_gate_min_never_increases():
+    x = 0.8
+    y = edges.gate_min(x, risk_multiplier=0.5)
+    assert y <= x

--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -1,0 +1,14 @@
+import pathlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from jfm.model import engine  # noqa: E402
+
+
+def test_simulate_writes_summary(tmp_path):
+    summary = engine.simulate(Path("model/current.yaml"), runs=10, seed=1)
+    assert 0.0 <= summary["P(N12)"] <= 1.0
+    runs_dir = Path("runs")
+    assert any((d / "summary.json").exists() for d in runs_dir.iterdir())

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from jfm.io.loader import load_graph, ValidationError  # noqa: E402
+
+
+def test_load_valid_graph(tmp_path: Path):
+    data = load_graph(Path("model/current.yaml"))
+    assert "nodes" in data
+    assert "edges" in data
+
+
+def test_invalid_graph(tmp_path: Path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("invalid: true")
+    with pytest.raises(ValidationError):
+        load_graph(bad)


### PR DESCRIPTION
## Summary
- set up `jfm` package with Typer CLI and Monte Carlo engine
- add edge function implementations and YAML model loader with schema validation
- provide sample model, tests, and project tooling

## Testing
- `pre-commit run --files $(git diff --name-only --cached)`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e5cc3a24832ba7f243d09f0ce67d